### PR TITLE
fix: improve bash version check for better compatibility

### DIFF
--- a/update_services.sh
+++ b/update_services.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Check bash version (requires 4.0+ for associative arrays)
-if ((BASH_VERSINFO[0] < 4)); then
-    echo "Error: This script requires Bash 4.0 or higher (current version: $BASH_VERSION)"
+if [ -z "${BASH_VERSINFO}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    echo "Error: This script requires Bash 4.0 or higher (current version: ${BASH_VERSION:-unknown})"
     echo "macOS ships with Bash 3.2. Install a newer version with: brew install bash"
     echo "Then run this script with: /opt/homebrew/bin/bash $0"
     exit 1


### PR DESCRIPTION
fixes #154

changed the bash version check from arithmetic evaluation `(( ))` to standard test syntax `[ ]`. the original check was causing syntax errors when run with sh or older shells because `(( ))` isn't portable and would fail before the version check could even run.

now checks if BASH_VERSINFO exists before trying to use it, which gives a clearer error message when run with non-bash shells.